### PR TITLE
Fixes to the ODH install on CRC howto

### DIFF
--- a/docs/downstream/crc.md
+++ b/docs/downstream/crc.md
@@ -22,7 +22,7 @@ As an alternative you can install the prerequisites locally:
  * Fork https://github.com/operate-first/continuous-deployment
 
  * Import GPG key that is used by kustomize to encrypt the secrets.\
-    ```base64 -d < examples/key.asc | gpg --import ```
+   ```base64 -d < examples/key.asc | gpg --import ```
 
  * Proceed with [setup_argocd_dev_environment.md](../setup_argocd_dev_environment.md)
 

--- a/docs/downstream/odh-install-crc.md
+++ b/docs/downstream/odh-install-crc.md
@@ -25,7 +25,7 @@ Our ArgoCD SA `argocd-manager` needs to have access to the new project. On CRC I
 Then you need to change the `dev-cluster` to include all projects/namespace. (This is done by actually removing the value of `namespace`).
 
 ```bash
-oc patch secret dev-cluster-spec -n aicoe-argocd-dev --type='json' -p="[{'op': 'add', 'path': '/data/namespace', 'value':''}]"
+oc patch secret dev-cluster-spec -n aicoe-argocd-dev --type='json' -p="[{'op': 'replace', 'path': '/data/namespaces', 'value':''}]"
 ```
 
 Be aware that if you change this value in the ArgoCD UI, you might loose the stored credentials for the cluster due to a bug in ArgoCD.

--- a/examples/odh-deployment-app.yaml
+++ b/examples/odh-deployment-app.yaml
@@ -1,5 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
+metadata:
+  name: odh-deployment
 spec:
   destination:
     namespace: odh-deployment

--- a/examples/odh-operator-app.yaml
+++ b/examples/odh-operator-app.yaml
@@ -1,5 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
+metadata:
+  name: odh-operator
 spec:
   destination:
     namespace: odh-operator


### PR DESCRIPTION
Retested after myself and found issues:

 * missing `metadata.name` in both Application resources.
 * typos in the `oc patch` command
 