### PR TITLE
Multiple gpg

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - anishasthana
+  - hemajv
+  - HumairAK
+  - tumido
+  - martinpovolny
+  - 4n4nd
+  - durandom
+
+reviewers:
+  - anishasthana
+  - hemajv
+  - HumairAK
+  - tumido
+  - martinpovolny
+  - 4n4nd

--- a/manifests/base/deployments/argocd-repo-server_patch.yaml
+++ b/manifests/base/deployments/argocd-repo-server_patch.yaml
@@ -17,7 +17,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/sh", "-c", "gpg --import /key/private.key"]
+              command: ["/bin/sh", "-c", "gpg --import /key/*"]
       volumes:
       - name: key
         secret:

--- a/manifests/base/services/argocd_metrics_service_patch.yaml
+++ b/manifests/base/services/argocd_metrics_service_patch.yaml
@@ -3,4 +3,4 @@ kind: Service
 metadata:
   name: argocd-metrics
   labels:
-    app.kubernetes.io/purpose: aicoe-cd-metrics
+    app.kubernetes.io/purpose: argocd-metrics

--- a/manifests/base/services/argocd_server_metrics_service_patch.yaml
+++ b/manifests/base/services/argocd_server_metrics_service_patch.yaml
@@ -3,4 +3,4 @@ kind: Service
 metadata:
   name: argocd-server-metrics
   labels:
-    app.kubernetes.io/purpose: aicoe-cd-metrics
+    app.kubernetes.io/purpose: argocd-metrics


### PR DESCRIPTION
Add support for multiple gpg keys that argocd can use to decrypt, would just need to add them to the gpg secret. 
Also removed aicoe references in services labels. 
Also add owners file.