### PR TITLE
Update ODH apps to reflect odh repo changes

### DIFF
--- a/docs/downstream/odh-install-crc.md
+++ b/docs/downstream/odh-install-crc.md
@@ -10,11 +10,11 @@ oc get packagemanifests -n openshift-marketplace | grep opendatahub-operator
 
 If it's not present, then you need to troubleshoot the marketplace: https://github.com/operator-framework/operator-marketplace/issues/344
 
-Then we need to create a projects named `odh-operator` and `odh-deployment-*`. (The name of the project is hard-coded in the `kustomize` files in https://github.com/anishasthana/my-odh-install and you can change is there using `kustomize`.)
+Then we need to create a projects named `odh-operator` and `opf-*`. (The name of the project is hard-coded in the `kustomize` files in https://github.com/operate-first/odh and you can change is there using `kustomize`.)
 
 ```bash
 oc new-project odh-operator
-oc new-project odh-deployment-{jupyterhub,superset}
+oc new-project opf-{jupyterhub,superset}
 ```
 
 Our ArgoCD SA `argocd-manager` needs to have access to the new project. On CRC I suggest giving `argocd-manager` access to all projects by creating a ClusterRoleBinding to a ClusterRole.
@@ -34,7 +34,7 @@ Be aware that if you change this value in the ArgoCD UI, you might loose the sto
 Now we can proceed with creating the ArgoCD Applications. We will create 2 applications:
 
 1. The ODH operator. (Installs the ODH operator itself `odh-operator`.)
-1. The ODH deployment. (Installs ODH components into `odh-deployment-*`.)
+1. The ODH deployment. (Installs ODH components into `opf-*`.)
 
 ### Creating the ODH operator
 
@@ -78,7 +78,7 @@ or again going to https://argocd-server-aicoe-argocd-dev.apps-crc.testing/applic
 | ---------------- | ------------------------------------------ |
 | Project:         | Default                                    |
 | Cluster:         | dev-cluster (https://api.crc.testing.6443) |
-| Namespace:       | odh-deployment-jupyterhub                  |
+| Namespace:       | opf-jupyterhub                             |
 | Repo URL:        | https://github.com/operate-first/odh.git   |
 | Target revision: | HEAD                                       |
 | Path:            | kfdef/jupyterhub                           |
@@ -87,7 +87,7 @@ or again going to https://argocd-server-aicoe-argocd-dev.apps-crc.testing/applic
 | ---------------- | ------------------------------------------ |
 | Project:         | Default                                    |
 | Cluster:         | dev-cluster (https://api.crc.testing.6443) |
-| Namespace:       | odh-deployment-superset                    |
+| Namespace:       | opf-superset                               |
 | Repo URL:        | https://github.com/operate-first/odh.git   |
 | Target revision: | HEAD                                       |
 | Path:            | kfdef/superset                             |
@@ -101,13 +101,13 @@ Based on the content of `kfdef.yaml` (you will see components of ODH being creat
 You can find routes for your new ODH instance by running:
 
 ```bash
-$ oc get routes -n odh-deployment-jupyterhub
+$ oc get routes -n opf-jupyterhub
 NAME         HOST/PORT                                               PATH   SERVICES     PORT       TERMINATION     WILDCARD
-jupyterhub   jupyterhub-odh-deployment-jupyterhub.apps-crc.testing          jupyterhub   8080-tcp   edge/Redirect   None
+jupyterhub   jupyterhub-opf-jupyterhub.apps-crc.testing          jupyterhub   8080-tcp   edge/Redirect   None
 
-$ oc get routes -n odh-deployment-superset
+$ oc get routes -n opf-superset
 NAME         HOST/PORT                                               PATH   SERVICES     PORT       TERMINATION     WILDCARD
-superset     superset-odh-deployment-superset.apps-crc.testing              superset     8088-tcp                   None
+superset     superset-opf-superset.apps-crc.testing              superset     8088-tcp                   None
 ```
 
 To alter components deployed or anything else about the configuration fork https://github.com/operate-first/odh and replace references to this repo with your own fork.

--- a/docs/downstream/odh-install-crc.md
+++ b/docs/downstream/odh-install-crc.md
@@ -10,12 +10,11 @@ oc get packagemanifests -n openshift-marketplace | grep opendatahub-operator
 
 If it's not present, then you need to troubleshoot the marketplace: https://github.com/operator-framework/operator-marketplace/issues/344
 
-
-Then we need to create a projects named `odh-operator` and `odh-deployment`. (The name of the project is hard-coded in the `kustomize` files in https://github.com/anishasthana/my-odh-install and you can change is there using `kustomize`.)
+Then we need to create a projects named `odh-operator` and `odh-deployment-*`. (The name of the project is hard-coded in the `kustomize` files in https://github.com/anishasthana/my-odh-install and you can change is there using `kustomize`.)
 
 ```bash
 oc new-project odh-operator
-oc new-project odh-deployment
+oc new-project odh-deployment-{jupyterhub,superset}
 ```
 
 Our ArgoCD SA `argocd-manager` needs to have access to the new project. On CRC I suggest giving `argocd-manager` access to all projects by creating a ClusterRoleBinding to a ClusterRole.
@@ -34,8 +33,8 @@ Be aware that if you change this value in the ArgoCD UI, you might loose the sto
 
 Now we can proceed with creating the ArgoCD Applications. We will create 2 applications:
 
-  1. The ODH operator. (Installs the ODH operator itself `odh-operator`.)
-  1. The ODH deployment. (Installs ODH components into `odh-deployment`.)
+1. The ODH operator. (Installs the ODH operator itself `odh-operator`.)
+1. The ODH deployment. (Installs ODH components into `odh-deployment-*`.)
 
 ### Creating the ODH operator
 
@@ -47,21 +46,20 @@ oc apply -f examples/odh-operator-app.yaml
 
 Or you can go to https://argocd-server-aicoe-argocd-dev.apps-crc.testing/applications and click "New App" and entering these values:
 
-| Field            | Value                                                |
-|------------------|------------------------------------------------------|
-| Project:         | Default                                              |
-| Cluster:         | dev-cluster (https://api.crc.testing.6443)           |
-| Namespace:       | odh-operator                                         |
-| Repo URL:        | https://github.com/operate-first/odh.git             |
-| Target revision: | HEAD                                                 |
-| Path:            | odh-operator/base                                    |
+| Field            | Value                                      |
+| ---------------- | ------------------------------------------ |
+| Project:         | Default                                    |
+| Cluster:         | dev-cluster (https://api.crc.testing.6443) |
+| Namespace:       | odh-operator                               |
+| Repo URL:        | https://github.com/operate-first/odh.git   |
+| Target revision: | HEAD                                       |
+| Path:            | operator/base                              |
 
 This creates an app from definition in the repo under the path `odh-operator/base` and deploys it to the `odh-operator` namespace on the `dev-cluster`.
 
 This app is all about deploying the Open Data Hub operator to your cluster.
 
 Please note that the namespace is also hard-coded in the repo so changing it requires changing files in the repo.
-
 
 Create the app and you will see Argo deploying resources:
 ![ODH operator](../assets/images/crc/odh-operator.png)
@@ -76,14 +74,23 @@ oc apply -f examples/odh-deployment-app.yaml
 
 or again going to https://argocd-server-aicoe-argocd-dev.apps-crc.testing/applications, clicking "New App" and entering these values:
 
-| Field            | Value                                               |
-|------------------|-----------------------------------------------------|
-| Project:         | Default                                              |
-| Cluster:         | dev-cluster (https://api.crc.testing.6443)           |
-| Namespace:       | odh-deployment                                       |
-| Repo URL:        | https://github.com/operate-first/odh.git             |
-| Target revision: | HEAD                                                 |
-| Path:            | odh-operator-kfdef                                   |
+| Field            | Value                                      |
+| ---------------- | ------------------------------------------ |
+| Project:         | Default                                    |
+| Cluster:         | dev-cluster (https://api.crc.testing.6443) |
+| Namespace:       | odh-deployment-jupyterhub                  |
+| Repo URL:        | https://github.com/operate-first/odh.git   |
+| Target revision: | HEAD                                       |
+| Path:            | kfdef/jupyterhub                           |
+
+| Field            | Value                                      |
+| ---------------- | ------------------------------------------ |
+| Project:         | Default                                    |
+| Cluster:         | dev-cluster (https://api.crc.testing.6443) |
+| Namespace:       | odh-deployment-superset                    |
+| Repo URL:        | https://github.com/operate-first/odh.git   |
+| Target revision: | HEAD                                       |
+| Path:            | kfdef/superset                             |
 
 This is about the actual deployment of Open Data Hub to your cluster.
 
@@ -92,12 +99,15 @@ Based on the content of `kfdef.yaml` (you will see components of ODH being creat
 ![ODH operator](../assets/images/crc/odh-deployment.png)
 
 You can find routes for your new ODH instance by running:
-```bash
-$ oc get routes -n odh-deployment
-NAME         HOST/PORT                                    PATH   SERVICES     PORT       TERMINATION     WILDCARD
-jupyterhub   jupyterhub-odh-deployment.apps-crc.testing          jupyterhub   8080-tcp   edge/Redirect   None
-superset     superset-odh-deployment.apps-crc.testing            superset     8088-tcp                   None
-```
 
+```bash
+$ oc get routes -n odh-deployment-jupyterhub
+NAME         HOST/PORT                                               PATH   SERVICES     PORT       TERMINATION     WILDCARD
+jupyterhub   jupyterhub-odh-deployment-jupyterhub.apps-crc.testing          jupyterhub   8080-tcp   edge/Redirect   None
+
+$ oc get routes -n odh-deployment-superset
+NAME         HOST/PORT                                               PATH   SERVICES     PORT       TERMINATION     WILDCARD
+superset     superset-odh-deployment-superset.apps-crc.testing              superset     8088-tcp                   None
+```
 
 To alter components deployed or anything else about the configuration fork https://github.com/operate-first/odh and replace references to this repo with your own fork.

--- a/examples/odh-deployment-app.yaml
+++ b/examples/odh-deployment-app.yaml
@@ -1,10 +1,10 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: odh-deployment-jupyterhub
+  name: opf-jupyterhub
 spec:
   destination:
-    namespace: odh-deployment-jupyterhub
+    namespace: opf-jupyterhub
     name: dev-cluster
   project: default
   source:
@@ -21,10 +21,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: odh-deployment-superset
+  name: opf-superset
 spec:
   destination:
-    namespace: odh-deployment-superset
+    namespace: opf-superset
     name: dev-cluster
   project: default
   source:

--- a/examples/odh-deployment-app.yaml
+++ b/examples/odh-deployment-app.yaml
@@ -1,14 +1,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: odh-deployment
+  name: odh-deployment-jupyterhub
 spec:
   destination:
-    namespace: odh-deployment
+    namespace: odh-deployment-jupyterhub
     name: dev-cluster
   project: default
   source:
-    path: odh-operator-kfdef
+    path: kfdef/jupyterhub
     repoURL: https://github.com/operate-first/odh.git
     targetRevision: HEAD
   syncPolicy:
@@ -16,4 +16,24 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - Validate=false
+      - Validate=false
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: odh-deployment-superset
+spec:
+  destination:
+    namespace: odh-deployment-superset
+    name: dev-cluster
+  project: default
+  source:
+    path: kfdef/superset
+    repoURL: https://github.com/operate-first/odh.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false


### PR DESCRIPTION
Required by: https://github.com/operate-first/odh/pull/3

Split the applications per ODH application - to have jupyterhub and supserset separatelly

Update the docs to reflect it.

Address changes introduced in  https://github.com/operate-first/odh/pull/7