### PR TITLE
Fix imagestreams for k8s deployments to pull from local registry

### DIFF
--- a/manifests/base/deployments/argocd-application-controller_patch.yaml
+++ b/manifests/base/deployments/argocd-application-controller_patch.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-application-controller
-  annotations:
-    alpha.image.policy.openshift.io/resolve-names: '*'
 spec:
   template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
       - image: argocd-custom

--- a/manifests/base/deployments/argocd-dex-server_patch.yaml
+++ b/manifests/base/deployments/argocd-dex-server_patch.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-dex-server
-  annotations:
-    alpha.image.policy.openshift.io/resolve-names: '*'
 spec:
   template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
       - name: dex

--- a/manifests/base/deployments/argocd-redis_patch.yaml
+++ b/manifests/base/deployments/argocd-redis_patch.yaml
@@ -6,8 +6,6 @@ metadata:
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
   name: argocd-redis
-  annotations:
-    alpha.image.policy.openshift.io/resolve-names: '*'
 spec:
   selector:
     matchLabels:
@@ -16,6 +14,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-redis
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
       - args:

--- a/manifests/base/deployments/argocd-repo-server_patch.yaml
+++ b/manifests/base/deployments/argocd-repo-server_patch.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-repo-server
-  annotations:
-    alpha.image.policy.openshift.io/resolve-names: '*'
 spec:
   template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
       - name: argocd-repo-server

--- a/manifests/base/deployments/argocd-server_patch.yaml
+++ b/manifests/base/deployments/argocd-server_patch.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-server
-  annotations:
-    alpha.image.policy.openshift.io/resolve-names: '*'
 spec:
   template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
       - name: argocd-server

--- a/manifests/base/imagestreams/argocd-custom.yaml
+++ b/manifests/base/imagestreams/argocd-custom.yaml
@@ -3,7 +3,11 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: argocd-custom
+  annotations:
+    openshift.io/display-name: argocd-custom
 spec:
+  lookupPolicy:
+    local: true
   tags:
     - name: latest
       from:

--- a/manifests/base/imagestreams/argocd-dex-server.yaml
+++ b/manifests/base/imagestreams/argocd-dex-server.yaml
@@ -3,7 +3,11 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: argocd-dex-server
+  annotations:
+    openshift.io/display-name: argocd-dex-server
 spec:
+  lookupPolicy:
+    local: true
   tags:
     - name: latest
       from:

--- a/manifests/base/imagestreams/redis.yaml
+++ b/manifests/base/imagestreams/redis.yaml
@@ -3,7 +3,11 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: redis
+  annotations:
+    openshift.io/display-name: redis
 spec:
+  lookupPolicy:
+    local: true
   tags:
     - name: latest
       from:


### PR DESCRIPTION
For more info on this procedure see [here](https://docs.openshift.com/container-platform/4.6/openshift_images/using-imagestreams-with-kube-resources.html)