### PR TITLE
[WIP] Make sure deployment work with the reworked structure of repos

### DIFF
--- a/deploy-odh-quicklab.sh
+++ b/deploy-odh-quicklab.sh
@@ -1,5 +1,3 @@
-API=upi-0.mptest.lab.upshift.rdu2.redhat.com:6443
-
 EMP="\e[1;4m"
 NORMAL="\e[0m"
 

--- a/examples/odh-deployment-app.yaml
+++ b/examples/odh-deployment-app.yaml
@@ -1,34 +1,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: opf-jupyterhub
+  name: opf-argo
 spec:
   destination:
-    namespace: opf-jupyterhub
+    namespace: opf-argo
     name: in-cluster
   project: default
   source:
-    path: odh/overlays/quicklab/jupyterhub
-    repoURL: https://github.com/operate-first/apps.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: opf-superset
-spec:
-  destination:
-    namespace: opf-superset
-    name: in-cluster
-  project: default
-  source:
-    path: odh/overlays/quicklab/superset
+    path: odh/overlays/quicklab/argo
     repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:

--- a/examples/odh-deployment-app.yaml
+++ b/examples/odh-deployment-app.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: default
   source:
-    path: kfdef/jupyterhub
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/overlays/quicklab/jupyterhub
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     automated:
@@ -28,8 +28,8 @@ spec:
     name: in-cluster
   project: default
   source:
-    path: kfdef/superset
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/overlays/quicklab/superset
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     automated:

--- a/examples/odh-operator-app.yaml
+++ b/examples/odh-operator-app.yaml
@@ -8,7 +8,7 @@ spec:
     name: in-cluster
   project: default
   source:
-    path: odh/base/operator
+    path: cluster-scope/base/subscriptions/opendatahub-operator
     repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:

--- a/examples/odh-operator-app.yaml
+++ b/examples/odh-operator-app.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: default
   source:
-    path: odh-operator/base
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/operator
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     automated:


### PR DESCRIPTION
There are 2 repos with the assets now:

https://github.com/operate-first/apps and https://github.com/operate-first/argocd-apps.

This is explained in https://github.com/operate-first/blueprint (ASR 4 and 5).

How it works now? 
In short the `apps` repo contains the manifests for the application and `argocd-apps` contains the ArgoCD `Application` resources.

For example, if you decide to create your own ArgoCD `Application` resource, you can point it to repo https://github.com/operate-first/apps.git and set path to  `odh/overlays/quicklab/jupyterhub/` and use that to install JupyterHub.

In a more complex setup you can use ArgoCD to create the ArgoCD resources for you. (Yes, have an ArgoCD app to create other ArgoCD apps the those deploy the applications for you). This way you have an "app of apps" that deploys the world for you.

Also if you build resources in https://github.com/operate-first/argocd-apps/tree/main/overlays/quicklab (using customize) you get a set of ArgoCD `Application` resources to deploy all the applications.

You can use the resources in the `operate-first` subdirectory to deploy only the operate first applications or you can use the individual files to deploy only parts.

If you want to have all of your things in your repo and have control over things you can checkout/fork 
https://github.com/operate-first/argocd-apps/ then edit the "app of apps", (build it using `kustomize build`) and point ArgoCD to your fork.

### FIXME:

 * This works for Quicklab, make sure it works for CRC too.

