### PR TITLE
Add mesh-for-data argocd project

### DIFF
--- a/manifests/overlays/moc-cnv/configs/argo_cm/dex.config
+++ b/manifests/overlays/moc-cnv/configs/argo_cm/dex.config
@@ -14,3 +14,4 @@ connectors:
         - operate-first
         - data-science
         - rekor
+        - mesh-for-data

--- a/manifests/overlays/moc-cnv/projects/kustomization.yaml
+++ b/manifests/overlays/moc-cnv/projects/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - data-science.yaml
   - thoth.yaml
   - rekor.yaml
+  - mesh-for-data.yaml

--- a/manifests/overlays/moc-cnv/projects/mesh-for-data.yaml
+++ b/manifests/overlays/moc-cnv/projects/mesh-for-data.yaml
@@ -1,0 +1,222 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: mesh-for-data
+spec:
+  destinations:
+    - namespace: 'm4d-*'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'mesh-for-data'
+      server: 'https://kubernetes.default.svc'
+  sourceRepos:
+    - '*'
+  roles:
+    - name: project-admin
+      description: Read/Write access to this project only
+      policies:
+        - p, proj:mesh-for-data:project-admin, applications, get, mesh-for-data/*, allow
+        - p, proj:mesh-for-data:project-admin, applications, create, mesh-for-data/*, allow
+        - p, proj:mesh-for-data:project-admin, applications, update, mesh-for-data/*, allow
+        - p, proj:mesh-for-data:project-admin, applications, delete, mesh-for-data/*, allow
+        - p, proj:mesh-for-data:project-admin, applications, sync, mesh-for-data/*, allow
+        - p, proj:mesh-for-data:project-admin, applications, override, mesh-for-data/*, allow
+        - p, proj:mesh-for-data:project-admin, applications, action/*, mesh-for-data/*, allow
+      groups:
+        - mesh-for-data
+        - operate-first
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+  namespaceResourceWhitelist:
+    - group: ''
+      kind: Binding
+    - group: ''
+      kind: ConfigMap
+    - group: ''
+      kind: Endpoints
+    - group: ''
+      kind: Event
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: PersistentVolumeClaim
+    - group: ''
+      kind: Pod
+    - group: ''
+      kind: ReplicationController
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: Secret
+    - group: ''
+      kind: ServiceAccount
+    - group: ''
+      kind: Service
+    - group: apps
+      kind: ControllerRevision
+    - group: apps
+      kind: DaemonSet
+    - group: apps
+      kind: Deployment
+    - group: apps
+      kind: ReplicaSet
+    - group: apps
+      kind: StatefulSet
+    - group: apps.openshift.io
+      kind: DeploymentConfig
+    - group: authorization.openshift.io
+      kind: RoleBindingRestriction
+    - group: authorization.openshift.io
+      kind: RoleBinding
+    - group: authorization.openshift.io
+      kind: Role
+    - group: autoscaling
+      kind: HorizontalPodAutoscaler
+    - group: batch
+      kind: CronJob
+    - group: batch
+      kind: Job
+    - group: build.openshift.io
+      kind: BuildConfig
+    - group: build.openshift.io
+      kind: Build
+    - group: cdi.kubevirt.io
+      kind: DataVolume
+    - group: ceph.rook.io
+      kind: CephBlockPool
+    - group: ceph.rook.io
+      kind: CephClient
+    - group: ceph.rook.io
+      kind: CephCluster
+    - group: ceph.rook.io
+      kind: CephFilesystem
+    - group: ceph.rook.io
+      kind: CephNFS
+    - group: ceph.rook.io
+      kind: CephObjectStore
+    - group: ceph.rook.io
+      kind: CephObjectStoreUser
+    - group: extensions
+      kind: Ingress
+    - group: hco.kubevirt.io
+      kind: HyperConverged
+    - group: image.openshift.io
+      kind: ImageStreamImage
+    - group: image.openshift.io
+      kind: ImageStreamMapping
+    - group: image.openshift.io
+      kind: ImageStream
+    - group: image.openshift.io
+      kind: ImageStreamTag
+    - group: image.openshift.io
+      kind: ImageTag
+    - group: kfdef.apps.kubeflow.org
+      kind: KfDef
+    - group: kubevirt.io
+      kind: KubeVirt
+    - group: kubevirt.io
+      kind: VirtualMachineInstanceMigration
+    - group: kubevirt.io
+      kind: VirtualMachineInstancePreset
+    - group: kubevirt.io
+      kind: VirtualMachineInstanceReplicaSet
+    - group: kubevirt.io
+      kind: VirtualMachineInstance
+    - group: kubevirt.io
+      kind: VirtualMachine
+    - group: local.storage.openshift.io
+      kind: LocalVolume
+    - group: metering.openshift.io
+      kind: HiveTable
+    - group: metering.openshift.io
+      kind: MeteringConfig
+    - group: metering.openshift.io
+      kind: PrestoTable
+    - group: metering.openshift.io
+      kind: ReportDataSource
+    - group: metering.openshift.io
+      kind: ReportQuery
+    - group: metering.openshift.io
+      kind: Report
+    - group: metering.openshift.io
+      kind: StorageLocation
+    - group: metrics.k8s.io
+      kind: PodMetrics
+    - group: networking.k8s.io
+      kind: Ingress
+    - group: networking.k8s.io
+      kind: NetworkPolicy
+    - group: noobaa.io
+      kind: BackingStore
+    - group: noobaa.io
+      kind: BucketClass
+    - group: noobaa.io
+      kind: NooBaa
+    - group: objectbucket.io
+      kind: ObjectBucketClaim
+    - group: ocs.openshift.io
+      kind: OCSInitialization
+    - group: ocs.openshift.io
+      kind: StorageClusterInitialization
+    - group: ocs.openshift.io
+      kind: StorageCluster
+    - group: operators.coreos.com
+      kind: CatalogSource
+    - group: operators.coreos.com
+      kind: ClusterServiceVersion
+    - group: operators.coreos.com
+      kind: InstallPlan
+    - group: operators.coreos.com
+      kind: OperatorGroup
+    - group: operators.coreos.com
+      kind: Subscription
+    - group: packages.operators.coreos.com
+      kind: PackageManifest
+    - group: policy
+      kind: PodDisruptionBudget
+    - group: quota.openshift.io
+      kind: AppliedClusterResourceQuota
+    - group: rbac.authorization.k8s.io
+      kind: RoleBinding
+    - group: rbac.authorization.k8s.io
+      kind: Role
+    - group: route.openshift.io
+      kind: Route
+    - group: ssp.kubevirt.io
+      kind: KubevirtCommonTemplatesBundle
+    - group: ssp.kubevirt.io
+      kind: KubevirtMetricsAggregation
+    - group: ssp.kubevirt.io
+      kind: KubevirtNodeLabellerBundle
+    - group: ssp.kubevirt.io
+      kind: KubevirtTemplateValidator
+    - group: tekton.dev
+      kind: Condition
+    - group: tekton.dev
+      kind: PipelineResource
+    - group: tekton.dev
+      kind: PipelineRun
+    - group: tekton.dev
+      kind: Pipeline
+    - group: tekton.dev
+      kind: TaskRun
+    - group: tekton.dev
+      kind: Task
+    - group: template.openshift.io
+      kind: Template
+    - group: template.openshift.io
+      kind: TemplateInstance
+    - group: template.openshift.io
+      kind: Template
+    - group: triggers.tekton.dev
+      kind: EventListener
+    - group: triggers.tekton.dev
+      kind: TriggerBinding
+    - group: triggers.tekton.dev
+      kind: TriggerTemplate
+    - group: upload.cdi.kubevirt.io
+      kind: UploadTokenRequest
+    - group: v2v.kubevirt.io
+      kind: OVirtProvider
+    - group: v2v.kubevirt.io
+      kind: V2VVmware


### PR DESCRIPTION
This will create the mesh-for-data argocd project, and allow `mesh-for-data` ocp group to log in and see apps belonging to the mesh-for-data argocd project.

Onboarding mesh-for-data, as per [request](https://github.com/operate-first/support/issues/41)

We're still in the middle of hooking up automation for deploying projects, so for now this change will need to be manually applied. 