### PR TITLE
Update ArgoCD to 1.8.3, helm-secrets, ksops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-ARG ARGO_CD_VERSION="v1.8.1"
+ARG ARGO_CD_VERSION="v1.8.3"
 # Always match Argo CD Dockerfile's Go version!
 # https://github.com/argoproj/argo-cd/blob/master/Dockerfile
-ARG KSOPS_VERSION="v2.3.2"
+ARG KSOPS_VERSION="v2.3.3"
 #--------------------------------------------#
 #--------Build KSOPS and Kustomize-----------#
 #--------------------------------------------#
 
-FROM viaductoss/ksops:$KSOPS_VERSION as ksops-builder
+FROM quay.io/viaductoss/ksops:$KSOPS_VERSION as ksops-builder
 
 #--------------------------------------------#
 #--------Build Custom Argo Image-------------#
 #--------------------------------------------#
 
-FROM argoproj/argocd:$ARGO_CD_VERSION
+FROM quay.io/argoproj/argocd:$ARGO_CD_VERSION
 
 # Switch to root for the ability to perform install
 USER root
@@ -23,7 +23,7 @@ ENV XDG_CACHE_HOME=/home/argocd/.cache
 ENV XDG_CONFIG_HOME=/home/argocd/.config
 ENV KUSTOMIZE_PLUGIN_PATH=$XDG_CONFIG_HOME/kustomize/plugin/
 ARG SOPS_VERSION="v3.6.1"
-ARG HELM_SECRETS_VERSION="2.0.2"
+ARG HELM_SECRETS_VERSION="3.4.1"
 ARG PKG_NAME=ksops
 
 # Override the default kustomize executable with the Go built version
@@ -41,7 +41,7 @@ RUN apt-get update && \
     curl -o /usr/local/bin/sops -L https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux && \
     chmod +x /usr/local/bin/sops && \
     mkdir -p $XDG_DATA_HOME/helm/plugins && \
-    helm plugin install https://github.com/zendesk/helm-secrets --version=$HELM_SECRETS_VERSION && \
+    helm plugin install https://github.com/jkroepke/helm-secrets --version=$HELM_SECRETS_VERSION && \
     chgrp -R 0 $XDG_DATA_HOME/helm/plugins/helm-secrets/ && \
     chmod -R g+rwX $XDG_DATA_HOME/helm/plugins/helm-secrets/
 

--- a/docs/admin/update_argocd.md
+++ b/docs/admin/update_argocd.md
@@ -43,6 +43,8 @@ If updating ArgoCD's version, bump the remote image references in the following 
 - ArgoCD namespace manifests [here](https://github.com/operate-first/continuous-deployment/blob/master/manifests/base/kustomization.yaml#L4)
 - ArgoCD cluster rbac [here](https://github.com/operate-first/continuous-deployment/blob/master/manifests/crds/kustomization.yaml#L5)
 
+Do a search for other references to `github.com/argoproj/argo-cd` remote references and update accordingly where applicable.
+
 # Update Container Images
 Under the `images` section [here](https://github.com/operate-first/continuous-deployment/blob/master/manifests/base/kustomization.yaml), update the `operate-first/argocd` tag to `vX.X.X-Y`. For example, if updating to `v1.8.1-2` we would have the following new image in our `Kustomization`:
 

--- a/docs/publish/versions.md
+++ b/docs/publish/versions.md
@@ -2,9 +2,9 @@
 
 We use the following tools with corresponding versions.
 
-ArgoCD: 1.8.1
+ArgoCD: 1.8.3
 
-KSOPs: 2.3.2
+KSOPs: 2.3.3
 
 Kustomize: 3.8.0
 
@@ -12,7 +12,7 @@ SOPS: 3.6.1
 
 Helm: 3.4.1
 
-Helm-Secrets: 2.0.2
+Helm-Secrets: 3.4.1
 
 The KSOPS and Kustomize versions refer to the ones provisioned with ArgoCD.
 

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/argoproj/argo-cd/manifests/base?ref=v1.8.1
+- github.com/argoproj/argo-cd/manifests/base?ref=v1.8.3
 - routes/argocd_server_route.yaml
 - serviceaccounts/argocd-manager.yaml
 patchesStrategicMerge:
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 images:
 - name: argoproj/argocd
   newName: quay.io/operate-first/argocd
-  newTag: v1.8.1-1
+  newTag: v1.8.3-1
 - name: redis
   newName: quay.io/operate-first/redis
   newTag: 5.0.10-alpine

--- a/manifests/crds/kustomization.yaml
+++ b/manifests/crds/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - aggregate-to-admin.yaml
-- github.com/argoproj/argo-cd/manifests/crds?ref=v1.8.1
+- github.com/argoproj/argo-cd/manifests/crds?ref=v1.8.3

--- a/manifests/overlays/moc-cnv/kustomization.yaml
+++ b/manifests/overlays/moc-cnv/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 resources:
 - ../../base
 - ../../crds
-- github.com/argoproj/argo-cd/manifests/cluster-rbac?ref=v1.8.1
+- github.com/argoproj/argo-cd/manifests/cluster-rbac?ref=v1.8.3
 - applications
 - projects
 - secrets/auth/dex-server-sa.yaml


### PR DESCRIPTION
As per instructions in this [doc](https://github.com/operate-first/continuous-deployment/blob/master/docs/admin/update_argocd.md)

Fixes #84 #90 #95 
Also slightly adds more info for update docs.

This should solve our build failures as well during ci for this repo in particular.