### PR TITLE
feat: Allow ArgoCD in operate-first project to deploy to openshift-logging

### DIFF
--- a/manifests/overlays/moc-cnv/projects/operate-first.yaml
+++ b/manifests/overlays/moc-cnv/projects/operate-first.yaml
@@ -8,6 +8,8 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: 'argocd'
       server: 'https://kubernetes.default.svc'
+    - namespace: 'openshift-logging'
+      server: 'https://kubernetes.default.svc'
   sourceRepos:
     - '*'
   roles:


### PR DESCRIPTION
Resolves: https://github.com/operate-first/apps/issues/174

Depends on: https://github.com/operate-first/apps/pull/173, https://github.com/operate-first/argocd-apps/pull/58