### PR TITLE
fix: ClusterLogging resource on whitelist for operate-first project

### DIFF
--- a/manifests/overlays/moc-cnv/projects/operate-first.yaml
+++ b/manifests/overlays/moc-cnv/projects/operate-first.yaml
@@ -105,6 +105,8 @@ spec:
       kind: CephObjectStore
     - group: ceph.rook.io
       kind: CephObjectStoreUser
+    - group: logging.openshift.io
+      kind: ClusterLogging
     - group: core.observatorium.io
       kind: Observatorium
     - group: extensions


### PR DESCRIPTION
Signed-off-by: Tomas Coufal <tcoufal@redhat.com>