### PR TITLE
Add ml prague workshop cluster

### DIFF
--- a/manifests/overlays/moc-base/projects/workshops.yaml
+++ b/manifests/overlays/moc-base/projects/workshops.yaml
@@ -8,6 +8,10 @@ spec:
   destinations:
     - namespace: "ws-*"
       server: 'https://api.cnv.massopen.cloud:6443'
+    - namespace: "ws-*"
+      server: 'https://api.cluster-9566.9566.example.opentlc.com:6443'
+    - namespace: "workshop-*"
+      server: 'https://api.cluster-9566.9566.example.opentlc.com:6443'
   sourceRepos:
     - "*"
   roles:

--- a/manifests/overlays/moc-base/secrets/clusters/ml-prague-ws.enc.yaml
+++ b/manifests/overlays/moc-base/secrets/clusters/ml-prague-ws.enc.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cluster-spec-ml-prague-workshop
+    labels:
+        argocd.argoproj.io/secret-type: cluster
+    annotations:
+        managed-by: argocd.argoproj.io
+type: Opaque
+stringData:
+    name: ml-prague-workshop
+    config: ENC[AES256_GCM,data:kmkWR23gjhZroW+aEGDUeFRIGf2nPXbVkHljK90B5FNitLTxnz0irmTwy+ZHIYpILk6crT3yCRMGYJg2FCPQT7A0srfxt/4YKhuVn+WwzJ2DMiFT0f553RIYxUVWvXI1l6mcRc7mAI9C0SKymFuW0PdG9hQx6Rf9zdvwaKG8a8dIJI1ACbUUKSTnuxPMz0mt6h1P4gKiBZbZuM+tjZgHYcuxhOi5KtJCKZkFt2/ga+NPvOJI9EoGRvLFAtTE3KXGrbPeKAF6QWVSymumFoOCDAgRjfBaldWaKVMgoE0A1ZHdyrbxvcIIb/K7Sup8rbDqSRbn5gIROgh5gSen0viZATFmx/6kQY72HC40negMyl7anVImeL93mavZwtX8eJ4Sa0CFqYFqLa4er6mtc8Mjfh41oYtgEi0QChnMoPZBfcCjwxdaUSiGdLVHTmM7FAo5H22iT9qEwvm6jC2Rd9yBUULpN0LfjXlzQuCea7Jnet8FyUkh4+Ba3BYE44Kb0VWsp1w87o4EgaMiHYN3oRPyJGSlA+HS3BJf3Y1PXyaiUnNwWqYwmy8oXsyXAGO+16U3Ep1rQYVS2R1dPjr+ReLaSqWY1Px5dOzX3QcbISR5+HsiWh4Iw1pCm9356js+bF5W1qgDy4Ig2r7z+xoPOnwQhH1MCu5aXHGTxub+eAq3G2Kx4H0kOZQHJzDpZ0q30BzkQ1VMo7f9CvsQ4O9hIy+caqTdVD/Ep3e0+RHCuZXNGfSnKR7CZF33I3iNnjlX2dIO4EekDoYigE6u3OicQpmLH5OZyz6a/NR20JEtfCGs20D3PeLRFqZ6SeaL3F+keNQ34yVolKllOHt4qXaUEfZ8Zkpk9w13jQJnJXqjDhRPs6P2Lz+KHGccbfaWj/v8k076XBBvcal0wL9LE9kocE30wQZ4Cc3SHd9VeU/C+D1LM7hpFMLikDc3vtbl4EkYWoc0Zmsze1WOo9psn8tCQVVF8OzFBPqbxOGvuqrZDVkMeDHODxlmokk0SrzW2RMQTmdrQGg7bocpOze2ELyhXJOgnHGbEa9L3IQY2GQyybrpbUAZFgjXB+IpOO1gFtCEZJUrPoy1ztg8UMm0sx3Y3+Nh7MGwzacrpSoDMHu3CfjLjhN3LSshnvDepZPMvK2z40LRShTPmUd+VZbW1eBFiNc6cw5Zsdo711FJoxxj1K7q/mGMc7mSS0mzH79kHOyVL6m+2Vv6Y7S78titkt3d9Qu+UAMFOt5VAZcMPNIF4RjIXnoweBJaTADouvE8Dww95b7oze7gRDu0hGtJEBS+zXvkjWrVmLyoB82KUUBfxC6iRe2DOl9VmsGLXAq3MbAA,iv:BNX8Zp5Bs3pCbKhQWK8QxYLc6UK8Mf2bmpEDYCScLig=,tag:Zr4pxsBxW3q69dl6dWTQbw==,type:str]
+    server: https://api.cluster-9566.9566.example.opentlc.com:6443
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-02-23T18:17:04Z'
+    mac: ENC[AES256_GCM,data:zF6Ae8+2/6CPmg3DoKnI/cOEWLJhKzCBY/8A1B9Dj0M6uJ0OBw/PA8X6F2Gj9ytAdKbW33t7eP//9c7bTDEh493K8Tukgu5sAGmOiiMStMJVGauuktFuM1tBFGv8ph8EDiV22CykGxT1fJD5P5yNsI4jInYDnN6g1UXmWSGnK4A=,iv:Mj8vEfzJJrSjqZJqHduFDZKwcBQ6/UUEF1IF33ClWsI=,tag:MtCmCEZ/yM4Mn2NM9KDtlA==,type:str]
+    pgp:
+    -   created_at: '2021-02-23T18:17:03Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAu9jYjJqKKXbsQbQhkP52jS3XsDTYWXsySUgA0jI6oscw
+            CpWCrI8EaqlnYMi2vzjvAy1nBvN0eVzcUg9BobmtQlrX3Bk6OdzYktGl0JQebhRK
+            A5h+CE3EobYp98ZaBfOZWU+HzpJr2f9nQ4Mxys0QlKNUR3ULG7ZLI8QzEzlXw0K6
+            flUygm8/833tKG9B9O8xg4sLt3URtGOHjOcNl8zH/bHoLZ4UKgPL5Jmbwvok3AcA
+            STbG9CWAELq3h2tO44ba4FVlQ88czMVThCnjn31csoAc7ptU8WWOTuaVrjBUFxev
+            a/Ms/YKFBiTY/b4BHlmKi162zP9Aa5FVHUirOe80goSEw+EAmW3NVrQHlTpMK88X
+            b4doFS9MZ4aCQSu5TCQQzSqOi51rNWv0tUijr1a3kYMx3BYl2QBL7hVvr254fKvA
+            4jatvWo3OgRwrDVnyWDVU5UnSaOIHtsKFs4N8sdrd+f6HeV1Y0oGs7szLRf8ikeh
+            YK88RGduo8XJe3uoRXeR3gXicpVeIpq9jQYgqyRb7sdRIA7OlmOu7vx1Coc2VhpD
+            /sFUweqfqCN/MvqK879ve7/shXZ90jXK85HDZdLSEQSTOfvMxn9ZViZmegwc7UFM
+            LyZy8Uxh92gb3tSeUtnZQ2JRFE2O9iI+e3qO/uuv7QvmXY+azmFr/SDpjqhYlb/S
+            XgF3hjUmbaU/MxpbbUjEzMXAA/dtwWq57ldX4b6/fO+O610ytRdICez1ei+Ac+cu
+            bxnmgseoedPEXHTLPA4NVPZg5mjflIfgsOUq5xVi9H6tQ3Jcm7MjDwEjUv3m4q0=
+            =unb2
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(config)$
+    version: 3.6.1

--- a/manifests/overlays/moc-base/secrets/clusters/secret-generator.yaml
+++ b/manifests/overlays/moc-base/secrets/clusters/secret-generator.yaml
@@ -5,3 +5,4 @@ metadata:
 files:
 - secrets/clusters/moc-cnv.enc.yaml
 - secrets/clusters/moc-infra.enc.yaml
+- secrets/clusters/ml-prague-ws.enc.yaml


### PR DESCRIPTION
This pr adds the rhpds cluster to argocd. I've named it a bit generic to `ml-prague-workshop` incase we want to switch rhpds to the aws cluster, this way we won't need to update the app destination names.