### PR TITLE
Exclude the tekton based resources from argocd

### DIFF
--- a/manifests/overlays/moc-infra/configs/argo_cm/resource.exclusions
+++ b/manifests/overlays/moc-infra/configs/argo_cm/resource.exclusions
@@ -1,0 +1,7 @@
+- apiGroups:
+  - "tekton.dev"
+  kinds:
+  - "PipelineRun"
+  - "TaskRun"
+  clusters:
+  - "*"

--- a/manifests/overlays/moc-infra/kustomization.yaml
+++ b/manifests/overlays/moc-infra/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
   - configs/argo_cm/dex.config
   - configs/argo_cm/configManagementPlugins
   - configs/argo_cm/globalProjects
+  - configs/argo_cm/resource.exclusions
   envs:
   - configs/argo_cm/envs
 - name: argocd-rbac-cm


### PR DESCRIPTION
Fixes [this issue](https://github.com/operate-first/argocd-apps/issues/65). 

This should come after [this](https://github.com/operate-first/continuous-deployment/pull/114). A rebase will be needed.
