### PR TITLE
fix: Enable read access without authentication

### DIFF
--- a/manifests/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
+++ b/manifests/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
@@ -6,6 +6,9 @@ p, role:standard-user, projects, get, *, allow
 p, role:standard-user, accounts, get, *, allow
 p, role:standard-user, gpgkeys, get, *, allow
 
+# Define a custom default role for a public anonymous users with read only access to workshops apps
+p, role:readonly-public, applications, get, workshops/*, allow
+
 # Give Openshift group (argocd-admins) the argocd admin role with unrestricted argocd access
 g, argocd-admins, role:admin
 

--- a/manifests/overlays/moc-infra/configs/argo_rbac_cm/policy.default
+++ b/manifests/overlays/moc-infra/configs/argo_rbac_cm/policy.default
@@ -1,0 +1,1 @@
+role:readonly-public

--- a/manifests/overlays/moc-infra/kustomization.yaml
+++ b/manifests/overlays/moc-infra/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
   behavior: replace
   files:
   - configs/argo_rbac_cm/policy.csv
+  - configs/argo_rbac_cm/policy.default
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/manifests/overlays/moc-infra/projects/workshops.yaml
+++ b/manifests/overlays/moc-infra/projects/workshops.yaml
@@ -18,13 +18,13 @@ spec:
     - name: project-admin
       description: Read/Write access to this project only
       policies:
-        - p, proj:workshops:project-admin, applications, get, data-science/*, allow
-        - p, proj:workshops:project-admin, applications, create, data-science/*, allow
-        - p, proj:workshops:project-admin, applications, update, data-science/*, allow
-        - p, proj:workshops:project-admin, applications, delete, data-science/*, allow
-        - p, proj:workshops:project-admin, applications, sync, data-science/*, allow
-        - p, proj:workshops:project-admin, applications, override, data-science/*, allow
-        - p, proj:workshops:project-admin, applications, action/*, data-science/*, allow
+        - p, proj:workshops:project-admin, applications, get, workshops/*, allow
+        - p, proj:workshops:project-admin, applications, create, workshops/*, allow
+        - p, proj:workshops:project-admin, applications, update, workshops/*, allow
+        - p, proj:workshops:project-admin, applications, delete, workshops/*, allow
+        - p, proj:workshops:project-admin, applications, sync, workshops/*, allow
+        - p, proj:workshops:project-admin, applications, override, workshops/*, allow
+        - p, proj:workshops:project-admin, applications, action/*, workshops/*, allow
       groups:
         - data-science
         - operate-first


### PR DESCRIPTION
Fixes: https://github.com/operate-first/continuous-deployment/issues/116

Enabling anonymous access is crucial for workshops, since we don't have user mapping on the workshop's cluster.

According to the docs, this PR should fix it.
https://argoproj.github.io/argo-cd/operator-manual/rbac/#anonymous-access

We already had the `users.anonymous.enabled=true` in the `argocd-cm` config map.

Also fixes the wrong project RBAC scope on the workshops `AppProject`.