### PR TITLE
allow operate-first group to deploy to tekton-pipelines namespaces

### DIFF
--- a/manifests/overlays/moc-infra/projects/operate-first.yaml
+++ b/manifests/overlays/moc-infra/projects/operate-first.yaml
@@ -12,6 +12,8 @@ spec:
       server: 'https://api.moc-infra.massopen.cloud:6443'
     - namespace: 'opf-*'
       server: 'https://api.zero.massopen.cloud:6443'
+    - namespace: 'tekton-pipelines'
+      server: 'https://api.zero.massopen.cloud:6443'
     - namespace: 'openshift-logging'
       server: 'https://api.zero.massopen.cloud:6443'
     - namespace: 'kubeflow'


### PR DESCRIPTION
allow operate-first group to deploy to tekton prefix namespaces
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/operate-first/apps/issues/192#issuecomment-804086819