### PR TITLE
Update ArgoCD, KSOPS, & SOPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG ARGO_CD_VERSION="v2.0.1"
+ARG ARGO_CD_VERSION="v2.1.2"
 # Always match Argo CD Dockerfile's Go version!
 # https://github.com/argoproj/argo-cd/blob/master/Dockerfile
-ARG KSOPS_VERSION="v2.5.5"
+ARG KSOPS_VERSION="v3.0.1"
 #--------------------------------------------#
 #--------Build KSOPS and Kustomize-----------#
 #--------------------------------------------#
@@ -23,14 +23,15 @@ ENV XDG_CACHE_HOME=/home/argocd/.cache
 ENV XDG_CONFIG_HOME=/home/argocd/.config
 ENV KUSTOMIZE_PLUGIN_PATH=$XDG_CONFIG_HOME/kustomize/plugin/
 ARG SOPS_VERSION="v3.7.1"
-ARG HELM_SECRETS_VERSION="3.4.1"
+ARG HELM_SECRETS_VERSION="3.6.0"
 ARG PKG_NAME=ksops
 
 # Override the default kustomize executable with the Go built version
 COPY --from=ksops-builder /go/bin/kustomize /usr/local/bin/kustomize
 
 # Copy the plugin to kustomize plugin path
-COPY --from=ksops-builder /go/src/github.com/viaduct-ai/kustomize-sops/*  $KUSTOMIZE_PLUGIN_PATH/viaduct.ai/v1/${PKG_NAME}/
+COPY --from=ksops-builder /go/src/github.com/viaduct-ai/kustomize-sops/*  \
+    $KUSTOMIZE_PLUGIN_PATH/viaduct.ai/v1/${PKG_NAME}/
 
 # Install helm secrets and sops
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ This repo contains the Operate-First ArgoCD custom Image. The image is used by t
 
 We use the following tools with corresponding versions.
 
-ArgoCD: 2.0.1
+ArgoCD: 2.1.2
 
-KSOPs: 2.5.5
+KSOPs: 3.0.1
 
-Kustomize: 4.1.1
+Kustomize: 4.3.0
 
 SOPS: 3.7.1
 
-Helm: 3.4.1
+Helm: 3.6.0
 
-Helm-Secrets: 3.4.1
+Helm-Secrets: 3.6.0
 
 The KSOPS and Kustomize versions refer to the ones provisioned with ArgoCD.
 


### PR DESCRIPTION
Update tooling in preparation for ArgoCD 2.1.2 upgrade.

Part of operate-first/sre#385
