### PR TITLE
Add the kustomize-hash-annotator kustomize plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 exclude: /configs
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.1
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:
       - id: trailing-whitespace

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,9 @@ RUN apt-get update && \
     mkdir -p $XDG_DATA_HOME/helm/plugins && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version=$HELM_SECRETS_VERSION && \
     chgrp -R 0 $XDG_DATA_HOME/helm/plugins/helm-secrets/ && \
-    chmod -R g+rwX $XDG_DATA_HOME/helm/plugins/helm-secrets/
+    chmod -R g+rwX $XDG_DATA_HOME/helm/plugins/helm-secrets/ && \
+    mkdir -p $KUSTOMIZE_PLUGIN_PATH/pcjun97/v1/hashannotator && \
+    curl -L https://github.com/pcjun97/kustomize-hash-annotator/releases/download/1.0.1/HashAnnotator_1.0.1_Linux_x86_64.tar.gz | tar -xzf - -C $KUSTOMIZE_PLUGIN_PATH/pcjun97/v1/hashannotator/
 
 # Switch back to non-root user
 USER argocd


### PR DESCRIPTION
This adds the kustomize-hash-annotator [1] kustomize plugin to the
ArgoCD image. This plugin allows for dynamically annotating an object
with the hash of the contents of a configmap or secret, allowing for,
among other things, automatic rollouts of deployments based on updates
to configmaps and secrets.

[1]: https://github.com/pcjun97/kustomize-hash-annotator